### PR TITLE
set notice.Priority default to Unknown

### DIFF
--- a/feed/feed.go
+++ b/feed/feed.go
@@ -77,6 +77,7 @@ func GetNotice(entry *goquery.Selection) Notice {
 		ID:          GetID(entry),
 		Pkg:         GetPackageName(entry),
 		CVEs:        GetCves(entry),
+		Priority:    "Unknown",
 		Affects1604: Affects1604(entry),
 		Affects1804: Affects1804(entry),
 		Published:   GetPublished(entry),


### PR DESCRIPTION
With empty CVE list, the Priority is set to "", and so the following DynamoDB Stream process causes an error and many retries.